### PR TITLE
Use the ElementTraversal interface

### DIFF
--- a/src/dom/element/structs.js
+++ b/src/dom/element/structs.js
@@ -48,11 +48,11 @@ Element.include({
   },
 
   next: function(css_rule) {
-    return this.nextSiblings(css_rule)[0];
+    return !css_rule && this._.nextElementSibling !== undefined ? wrap(this._.nextElementSibling) : this.nextSiblings(css_rule)[0];
   },
 
   prev: function(css_rule) {
-    return this.prevSiblings(css_rule)[0];
+    return !css_rule && this._.previousElementSibling !== undefined ? wrap(this._.previousElementSibling) : this.prevSiblings(css_rule)[0];
   },
 
   /**

--- a/src/dom/selector.js
+++ b/src/dom/selector.js
@@ -16,7 +16,7 @@
    * @return Element matching node or null
    */
   first: function(css_rule) {
-    return wrap(this._.querySelector(css_rule || '*'));
+    return !css_rule && this._.firstElementChild !== undefined ? wrap(this._.firstElementChild) : wrap(this._.querySelector(css_rule || '*'));
   },
 
   /**


### PR DESCRIPTION
Make use of `ElementTraversal` properties for `.next()`, `.prev()` and `.first()` when possible (when there’s no `css_rule` argument passed).

See: http://www.quirksmode.org/dom/w3c_core.html#traversal
