### PR TITLE
Number#downto and #upto now return an array if called without a callback argument

### DIFF
--- a/src/lang/number.js
+++ b/src/lang/number.js
@@ -23,17 +23,33 @@ Number.include({
   },
 
   upto: function(number, callback, scope) {
-    for (var i=this+0; i <= number; i++) {
-      callback.call(scope, i);
+    if (callback === undefined) {
+      var numbers = [];
+      for (var i=this+0; i <= number; i++) {
+        numbers.push(i);
+      }
+      return numbers;
+    } else {
+      for (var i=this+0; i <= number; i++) {
+        callback.call(scope, i);
+      }
+      return this;
     }
-    return this;
   },
 
   downto: function(number, callback, scope) {
-    for (var i=this+0; i >= number; i--) {
-      callback.call(scope, i);
+    if (callback === undefined) {
+      var numbers = [];
+      for (var i=this+0; i >= number; i--) {
+        numbers.push(i);
+      }
+      return numbers;
+    } else {
+      for (var i=this+0; i >= number; i--) {
+        callback.call(scope, i);
+      }
+      return this;
     }
-    return this;
   },
 
   abs: function() {

--- a/test/unit/lang/number_test.js
+++ b/test/unit/lang/number_test.js
@@ -24,23 +24,35 @@ var NumberTest = TestCase.create({
   },
 
   testUpto: function() {
-    this.list = [];
-
-    (2).upto(8, function(i) {
-      this.list.push(i);
-    }, this);
+    this.list = (2).upto(8);
 
     this.assertEqual([2,3,4,5,6,7,8], this.list);
   },
 
+  testUptoWithCallback: function() {
+    this.list = [];
+
+    (2).upto(8, function(i) {
+      this.list.push(i * 2);
+    }, this);
+
+    this.assertEqual([4,6,8,10,12,14,16], this.list);
+  },
+
   testDownto: function() {
+    this.list = (8).downto(4);
+
+    this.assertEqual([8,7,6,5,4], this.list);
+  },
+
+  testDowntoWithCallback: function() {
     this.list = [];
 
     (8).downto(4, function(i) {
-      this.list.push(i);
+      this.list.push(i / 2);
     }, this);
 
-    this.assertEqual([8,7,6,5,4], this.list);
+    this.assertEqual([4,3.5,3,2.5,2], this.list);
   },
 
   testAbs: function() {

--- a/util/right-server.js
+++ b/util/right-server.js
@@ -1223,17 +1223,33 @@ Number.include({
   },
 
   upto: function(number, callback, scope) {
-    for (var i=this+0; i <= number; i++) {
-      callback.call(scope, i);
+    if (callback === undefined) {
+      var numbers = [];
+      for (var i=this+0; i <= number; i++) {
+        numbers.push(i);
+      }
+      return numbers;
+    } else {
+      for (var i=this+0; i <= number; i++) {
+        callback.call(scope, i);
+      }
+      return this;
     }
-    return this;
   },
 
   downto: function(number, callback, scope) {
-    for (var i=this+0; i >= number; i--) {
-      callback.call(scope, i);
+    if (callback === undefined) {
+      var numbers = [];
+      for (var i=this+0; i >= number; i--) {
+        numbers.push(i);
+      }
+      return numbers;
+    } else {
+      for (var i=this+0; i >= number; i--) {
+        callback.call(scope, i);
+      }
+      return this;
     }
-    return this;
   },
 
   abs: function() {


### PR DESCRIPTION
As per the example at http://rightjs.org/docs/number#upto people must often be using #upto and #downto in the simplest way:

```
var numbers = [];

4..upto(8, function(i) {
  numbers.push(i);
});

numbers; // -> [4,5,6,7,8]
```

I thought it’d be nice and clean to make this the default behavior if no callback is given:

```
var numbers = 4..upto(8); // numbers == [4,5,6,7,8]
```

How do you like it? Is it OK that the return value can now be of two different types?
