### PR TITLE
Don't include xhr/form.js when building RightJS with Xhr but without Form module. 

### DIFF
--- a/Nakefile
+++ b/Nakefile
@@ -85,6 +85,11 @@ task('pack', 'Pack the source code into a single file', function() {
       files = files.concat(js_sources[module]);
     }
   }
+  
+  // If form is not included but xhr is then don't include xhr/form
+  if (options.include('no-form') && !options.include('no-xhr')) {
+    files.splice(files.indexOf('xhr/form'), 1);
+  }
 
   // creating the build
   build = new Source({


### PR DESCRIPTION
Currently when using such a build an error "Form is not defined" is raised because there's no check if Form exists in xhr/form.js.
