### PR TITLE
Moved Xhr#prepareParams out of xhr.js as it requires Form object.

### DIFF
--- a/src/xhr/form.js
+++ b/src/xhr/form.js
@@ -82,3 +82,19 @@ function Form_remote_send(event, options) {
   event.stop();
   this.send(options);
 }
+
+/**
+ * Adds Xhr params handling if a Form element is passed to Xhr#send
+ * 
+ * @param Object params - could be Hash or Form element
+ * @return Object
+ */
+Xhr.include({
+  prepareParams: function(params) {
+    if (params && params instanceof Form) {
+      this.form = params;
+      params = params.values();
+    }
+    return params;
+  }
+});

--- a/src/xhr/xhr.js
+++ b/src/xhr/xhr.js
@@ -205,10 +205,6 @@ var Xhr = RightJS.Xhr = new Class(Observer, {
 
   // prepares user sending params
   prepareParams: function(params) {
-    if (('Form' in window) && params && params instanceof Form) {
-      this.form = params;
-      params = params.values();
-    }
     return params;
   },
 

--- a/src/xhr/xhr.js
+++ b/src/xhr/xhr.js
@@ -205,7 +205,7 @@ var Xhr = RightJS.Xhr = new Class(Observer, {
 
   // prepares user sending params
   prepareParams: function(params) {
-    if (params && params instanceof Form) {
+    if (('Form' in window) && params && params instanceof Form) {
       this.form = params;
       params = params.values();
     }


### PR DESCRIPTION
There's still some code in Xhr class which depends on Form object. Moved it out of xhr/xhr.js and included from xhr/form.js. 
