### PR TITLE
Fixed merging more than 2 hashes.

### DIFF
--- a/src/lang/object.js
+++ b/src/lang/object.js
@@ -134,8 +134,8 @@ $ext(Object, {
    * @return Object merged object
    */
   merge: function() {
-    var object = {}, i=0, l=0, args=arguments, key;
-    for (l = args.length; i < l; i++) {
+    var object = {}, i=0, args=arguments, l=args.length, key;
+    for (; i < l; i++) {
       if (isHash(args[i])) {
         for (key in args[i]) {
           object[key] = isHash(args[i][key]) && !(args[i][key] instanceof Class) ?

--- a/src/lang/object.js
+++ b/src/lang/object.js
@@ -134,7 +134,7 @@ $ext(Object, {
    * @return Object merged object
    */
   merge: function() {
-    var object = {}, i=0, args=arguments, key;
+    var object = {}, i=0, l=0, args=arguments, key;
     for (l = args.length; i < l; i++) {
       if (isHash(args[i])) {
         for (key in args[i]) {

--- a/test/unit/lang/object_test.js
+++ b/test/unit/lang/object_test.js
@@ -72,6 +72,19 @@ var ObjectTest = TestCase.create({
       "checking that all the keys were delinked"
     );
   },
+  
+  testThreeWayDeepMerge: function() {
+    var o1 = {a: {a1: 1}};
+    var o2 = {b: {b1: 2}};
+    var o3 = {a: {a1: 2, a2: 3}};
+    
+    var o = Object.merge(o1, o2, o3);
+    
+    this.assertEqual(
+      {a: {a1: 2, a2: 3}, b: {b1: 2}}, o,
+      "should do a deep merge with overriding"
+    );
+  },
 
   testClone: function() {
     var o1 = {1:1};


### PR DESCRIPTION
This problem was due to undeclared 'l' variable in Object#merge, so recursive calls were resetting this variable to 2 (because recursive merge is always done on 2 hashes) as it was declared in the global scope.
