### PR TITLE
Fixing two issues related to Element#set and Element#erase

### DIFF
--- a/src/dom/element/commons.js
+++ b/src/dom/element/commons.js
@@ -64,6 +64,7 @@ Element.include({
    */
   erase: function(name) {
     this._.removeAttribute(name);
+    delete this._[name];
     return this;
   },
 

--- a/src/dom/element/commons.js
+++ b/src/dom/element/commons.js
@@ -18,14 +18,14 @@ Element.include({
   set: function(hash, value) {
     if (typeof(hash) === 'string') { var val = {}; val[hash] = value; hash = val; }
 
-    var key, element = this._;
+    var key, element = this._, dummyElement = document.createElement('a');
 
     for (key in hash) {
       if (key === 'style') {
         this.setStyle(hash[key]);
       } else {
         // some attributes are not available as properties
-        if (!(key in element)) {
+        if (!(key in dummyElement)) {
           element.setAttribute(key, ''+hash[key]);
         }
         element[key] = hash[key];

--- a/src/dom/element/commons.js
+++ b/src/dom/element/commons.js
@@ -18,14 +18,14 @@ Element.include({
   set: function(hash, value) {
     if (typeof(hash) === 'string') { var val = {}; val[hash] = value; hash = val; }
 
-    var key, element = this._, dummyElement = document.createElement('a');
-
+    var key, element = this._;
+    
     for (key in hash) {
       if (key === 'style') {
         this.setStyle(hash[key]);
       } else {
         // some attributes are not available as properties
-        if (!(key in dummyElement)) {
+        if (!(key in tmp_cont)) {
           element.setAttribute(key, ''+hash[key]);
         }
         element[key] = hash[key];

--- a/test/unit/dom/element/commons_test.js
+++ b/test/unit/dom/element/commons_test.js
@@ -62,6 +62,14 @@ var ElementCommonsTest = TestCase.create({
     this.assertSame(this.el, this.el.erase('id'));
     this.assertFalse(this.el.has('id'));
   },
+  
+  testEraseCustom: function() {
+    this.el.set('data-boo', 'boo');
+    this.el.erase('data-boo');
+    
+    this.assertEqual(null, this.el.get('data-boo'));
+    this.assertEqual(undefined, this.el._['data-boo']);
+  },
 
   testHidden: function() {
     this.assertFalse(this.el.hidden());

--- a/test/unit/dom/element/commons_test.js
+++ b/test/unit/dom/element/commons_test.js
@@ -143,5 +143,24 @@ var ElementCommonsTest = TestCase.create({
     this.assertVisible(div3._, 'div3');
     this.assertHidden(div2._);
     this.assertHidden(div1._);
+  },
+  
+  testMatchCustomProperty: function() {
+    var el = new Element('div', { 'data-boo': 'boo' });
+    this.assert(el.match('div[data-boo=boo]'));
+    
+    el.set('data-boo', 'foo');
+    this.assert(el.match('div[data-boo=foo]'));
+  },
+  
+  testSearchByUpdatedCustomProperty: function() {
+    var parent = new Element('div');
+    var child = new Element('div', { 'data-boo': 'boo' });
+    parent.append(child);
+    
+    this.assertSame(child, parent.first('[data-boo=boo]'));
+    
+    child.set('data-boo', 'foo');
+    this.assertSame(child, parent.first('[data-boo=foo]'));
   }
 })


### PR DESCRIPTION
Problem #1:

Element#set does not update attribute's value (via setAttribute) when called for the second time, which affects CSS queries. I wasn't sure if it's save to remove line #28 in commons.js so instead added checking for attribute's presence in some dummy Element.
This could be a performance bottleneck as dummy element is created each time Element#set is called. Please feel free to suggest alternative solution.

Problem #2:
When erasing custom attribute via Element#erase it's removed via removeAttribute method but it's still accessible via native Element object as it's set that way in line #31 of Element#set. 
