### PR TITLE
Fixed String#endsWith when comparing two completely different strings may yield a positive result

### DIFF
--- a/src/lang/string.js
+++ b/src/lang/string.js
@@ -159,10 +159,10 @@ String.include({
    * @return boolean check result
    */
   endsWith: function(string, ignorecase) {
-    return this.length - (
-      ignorecase !== true ? this.lastIndexOf(string) :
-        this.toLowerCase().lastIndexOf(string.toLowerCase())
-    ) === string.length;
+    var index = ignorecase !== true ?
+      this.lastIndexOf(string) :
+      this.toLowerCase().lastIndexOf(string.toLowerCase());
+    return index > -1 && this.length - index === string.length;
   },
 
   /**

--- a/test/unit/lang/string_test.js
+++ b/test/unit/lang/string_test.js
@@ -99,6 +99,7 @@ var StringTest = TestCase.create({
   testEndsWith: function() {
     this.assert('asdf qwer'.endsWith('qwer'));
     this.assertFalse('asdf qwer'.endsWith('Qwer'));
+    this.assertFalse('asdf'.endsWith('qwert'));
 
     this.assert('asdf qwer'.endsWith('Qwer', true), 'test checking with ignore case');
   },


### PR DESCRIPTION
Let's say there are two strings.
var s1 = "ABCD";
var s2 = "12345";

According to buggy implementation when doing s1.endsWith(s2) it really does the following 
s1.length - s1.lastIndexOf(s2) === s2.length

Since s1.lastIndexOf(s2) is -1 in this case then #endsWith returns true because
4 - (-1) === 5

Feel free to tweak the code to match your preference.
